### PR TITLE
[Fix] Fixed word splitting REGEX for numbers close to eachother

### DIFF
--- a/src/string-to-sequence.js
+++ b/src/string-to-sequence.js
@@ -2,7 +2,7 @@
 
 const stringToSequence = (
   doc: string,
-  sepRe: RegExp | string = /[a-zA-ZÀ-ÿ]+/g
+  sepRe: RegExp | string = /[0-9a-zA-ZÀ-ÿ]+/g
 ) => {
   if (typeof sepRe === "string") {
     sepRe = new RegExp(sepRe, "g")


### PR DESCRIPTION
## Description

This pull request is expected to fix issue [#19](https://github.com/UniversalDataTool/react-nlp-annotate/issues/19) which would really help in my work. As also said, I am not familiar with this code and I gladly accept any suggestions and corrections needed, so feel free !!!